### PR TITLE
Add slash to image URI

### DIFF
--- a/src/plantuml_backend.rs
+++ b/src/plantuml_backend.rs
@@ -153,7 +153,7 @@ impl PlantUMLBackend for PlantUMLShell {
         // Cannot use PathBuf here, because on windows this would include back
         // slashes instead of forward slashes as the separator.
         Ok(format!(
-            "img/{}",
+            "/img/{}",
             output_file.file_name().unwrap().to_str().unwrap()
         ))
     }


### PR DESCRIPTION
As all diagrams are created in `book/img` we need to ensure that the
browser always fetch the images from <host>/img/<generated_file>.

If we don't specify that images are served from the root, the browser
will expect to a "img" directory to exist at each sub-path.

**Use case**: Books organised as <root>/<topic>/<file.md>, the diagram will be
created in <root>/img. So adding the slash to indicate that img is served from
the root makes the browser look for the right path, regardless of which level
the diagram is.

I wasn't able to easily create a test for it since it would require the file
rendering to be successful to get to the code where the path is generated. If
you have tips on how I can do it, I'm happy to add 😃 
