### PR TITLE
Support puml code block

### DIFF
--- a/src/markdown_plantuml_pipeline.rs
+++ b/src/markdown_plantuml_pipeline.rs
@@ -256,7 +256,7 @@ mod test {
                     assert!(fence_range.is_none());
                 }
             }};
-        };
+        }
 
         assert_find_next_code_fence!(None, "", 0, None, None);
         assert_find_next_code_fence!(None, "a\n\n", 0, None, None);
@@ -316,7 +316,7 @@ mod test {
                     assert!(slice.is_none());
                 }
             }};
-        };
+        }
 
         assert_get_info_string!("", 0, None);
         assert_get_info_string!("  ", 0, None);

--- a/src/markdown_plantuml_pipeline.rs
+++ b/src/markdown_plantuml_pipeline.rs
@@ -131,7 +131,7 @@ struct CodeBlock<'a> {
 
 impl<'a> CodeBlock<'a> {
     fn is_plantuml(&self) -> bool {
-        self.info_string.unwrap_or(&"") == "plantuml"
+        matches!(self.info_string.unwrap_or(&""), "puml" | "plantuml")
     }
 }
 
@@ -348,6 +348,7 @@ mod test {
             }};
         }
 
+        // Test for `plantuml` code block
         assert_plantuml_injection!("```plantuml\nfoo\n```", "foo\n", "rendered");
         assert_plantuml_injection!(
             "abc\n```plantuml\nfoo\n```\ndef",
@@ -367,6 +368,26 @@ mod test {
         );
         assert_plantuml_injection!(
             "abc\n```\nfoo\n```\ndef\n```plantuml\nbar",
+            "bar",
+            "abc\n```\nfoo\n```\ndef\nrendered"
+        );
+
+        // Test for `puml` code block
+        assert_plantuml_injection!("```puml\nfoo\n```", "foo\n", "rendered");
+        assert_plantuml_injection!("abc\n```puml\nfoo\n```\ndef", "foo\n", "abc\nrendered\ndef");
+        assert_plantuml_injection!("abc\n```puml\nfoo", "foo", "abc\nrendered");
+        assert_plantuml_injection!(
+            "abc\n```puml\nfoo\n```\ndef\n```puml\nbar\n```\ngeh",
+            "bar\n",
+            "abc\nrendered\ndef\nrendered\ngeh"
+        );
+        assert_plantuml_injection!(
+            "abc\n```puml\nfoo\n```\ndef\n```puml\nbar",
+            "bar",
+            "abc\nrendered\ndef\nrendered"
+        );
+        assert_plantuml_injection!(
+            "abc\n```\nfoo\n```\ndef\n```puml\nbar",
             "bar",
             "abc\n```\nfoo\n```\ndef\nrendered"
         );

--- a/src/plantuml_server_backend.rs
+++ b/src/plantuml_server_backend.rs
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_get_url_no_path() {
-        let srv = PlantUMLServer::new(Url::parse("http://froboz:1234").unwrap(), PathBuf::from(""));
+        let srv = PlantUMLServer::new(Url::parse("http://froboz:1234").unwrap());
 
         assert_eq!(
             Url::parse("http://froboz:1234/ext/plantuml_encoded_string").unwrap(),

--- a/src/plantuml_shell_backend.rs
+++ b/src/plantuml_shell_backend.rs
@@ -264,7 +264,8 @@ mod tests {
             Ok(_file_data) => assert!(false, "Expected the command to fail"),
             Err(e) => assert!(
                 e.to_string().contains("PlantUML did not generate an image"),
-                format!("Wrong error returned (got {})", e)
+                "Wrong error returned (got {})",
+                e
             ),
         };
     }
@@ -276,7 +277,7 @@ mod tests {
             Ok(file_data) => {
                 assert_eq!(expected_source, file_data);
             }
-            Err(e) => assert!(false, e.to_string()),
+            Err(e) => assert!(false, "{}", e),
         };
     }
 }


### PR DESCRIPTION
Some editors/plugins such as VSCode, IntelliJ support `puml` code block. This adds support for `puml` code block.