### PR TITLE
 Creating DataURI for image inlining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,7 @@ dependencies = [
 name = "mdbook-plantuml"
 version = "0.7.0"
 dependencies = [
+ "base64",
  "clap",
  "deflate",
  "env_logger 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ deflate = { version = "0.9.1", optional = true }
 sha1 = { version = "0.6.0", features = ["std"] }
 tempfile = "3.2.0"
 futures = "0.3.17"
+base64 = "0.13.0"
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"


### PR DESCRIPTION
Should solve the issue for this preprocesssor and create a better
user-experience. Also enables other downstream renderers to work
agnostically and not only the html renderer. Can convert text files to
data-uri but will still defer to the original text embedding method to
preserve historical functionality

- https://github.com/rust-lang/mdBook/issues/1087