### PR TITLE
Add experimental support of diagram generation through a pipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-plantuml"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base16ct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.5"
+version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
  "atty",
  "bitflags",
@@ -188,18 +188,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "3.2.1"
+version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6ebaab5f25e4f0312dfa07cb30a755204b96e6531457c2cfdecfdf5f2adf40"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.5"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.5",
  "typenum",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -327,12 +327,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime 1.3.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66d0c1b6e3abfd1e72818798925e16e02ed77e1b47f6c25a95a23b377ee4299"
+checksum = "36641a8b9deb60e23fb9bb47ac631d664a780b088909b89179a4eab5618b076b"
 dependencies = [
  "log",
  "pest",
@@ -492,9 +492,9 @@ checksum = "4726136a7636c738124814f1275dd59a709f4cf4dd7b4b670df95b6bf6c4a0ae"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -547,24 +547,15 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -610,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -662,9 +653,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -703,7 +694,7 @@ dependencies = [
  "chrono",
  "derivative",
  "fnv",
- "humantime 2.1.0",
+ "humantime",
  "libc",
  "log",
  "log-mdc",
@@ -732,9 +723,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mdbook"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74612ae81a3e5ee509854049dfa4c7975ae033c06f5fc4735c7dfbe60ee2a39d"
+checksum = "13cdad8057b09a519c6c63e6d7c93ea854f5d7fbfe284df864d5e1140d215a2d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -749,7 +740,6 @@ dependencies = [
  "pulldown-cmark",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "shlex",
  "tempfile",
@@ -759,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-plantuml"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base16ct",
@@ -851,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -873,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -905,9 +895,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
@@ -927,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "output_vt100"
@@ -1068,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -1087,16 +1077,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53dc8cf16a769a6f677e09e7ff2cd4be1ea0f48754aac39520536962011de0d"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -1112,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1129,9 +1113,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -1226,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
@@ -1245,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1256,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1279,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
@@ -1376,9 +1360,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -1495,10 +1479,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1568,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
 ]
@@ -1604,9 +1589,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unicase"
@@ -1625,15 +1610,15 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-plantuml"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Sytse Reitsma <mdbook-plantuml@sreitsma.nl>"]
 description = "A preprocessor for mdbook which will convert plantuml code blocks into inline SVG diagrams"
 license = "MIT"
@@ -20,8 +20,9 @@ doc = false
 
 [features]
 default = ["plantuml-ssl-server"]
-plantuml-server=["reqwest", "deflate"]
-plantuml-ssl-server=["reqwest/default-tls", "deflate"]
+exp-cmdline-pipe = []
+plantuml-server = ["reqwest", "deflate"]
+plantuml-ssl-server = ["reqwest/default-tls", "deflate"]
 
 [dependencies]
 mdbook = { version = "0.4.20", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,17 +24,17 @@ plantuml-server=["reqwest", "deflate"]
 plantuml-ssl-server=["reqwest/default-tls", "deflate"]
 
 [dependencies]
-mdbook = { version = "0.4.17", default-features = false }
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.79"
-log = "0.4.16"
-clap = { version = "3.1.8", features = ["derive"] }
-log4rs = "1.0.0"
-reqwest = { version = "0.11.10", optional = true, features = ["blocking"], default-features = false }
+mdbook = { version = "0.4.20", default-features = false }
+serde = { version = "1.0.139", features = ["derive"] }
+serde_json = "1.0.82"
+log = "0.4.17"
+clap = { version = "3.2.12", features = ["derive"] }
+log4rs = "1.1.1"
+reqwest = { version = "0.11.11", optional = true, features = ["blocking"], default-features = false }
 deflate = { version = "1.0.0", optional = true }
 sha1 = "0.10.1"
 base64 = "=0.20.0-alpha.1"
-anyhow = "1.0.55"
+anyhow = "1.0.58"
 tempfile = "3.3.0"
 base16ct = { version = "0.1.1", features = ["alloc"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,11 +56,7 @@ impl Preprocessor for PlantUMLPreprocessor {
     }
 }
 
-fn get_image_output_dir(
-    root: &PathBuf,
-    src_root: &PathBuf,
-    cfg: &PlantUMLConfig,
-) -> Result<PathBuf> {
+fn get_image_output_dir(root: &Path, src_root: &PathBuf, cfg: &PlantUMLConfig) -> Result<PathBuf> {
     let img_output_dir = {
         if cfg.use_data_uris {
             // Create the images in the book root dir (unmonitored by the serve command)

--- a/src/plantuml_backend.rs
+++ b/src/plantuml_backend.rs
@@ -12,6 +12,7 @@ pub trait PlantUMLBackend {
     fn render_from_string(
         &self,
         plantuml_code: &str,
+        chapter_path: &str,
         image_format: &str,
         output_file: &Path,
     ) -> Result<()>;

--- a/src/plantuml_backend_factory.rs
+++ b/src/plantuml_backend_factory.rs
@@ -1,6 +1,9 @@
 use crate::plantuml_backend::PlantUMLBackend;
+#[cfg(feature = "exp-cmdline-pipe")]
+use crate::plantuml_cmdline_backend::PlantUMLExecutableBackend;
 #[cfg(any(feature = "plantuml-ssl-server", feature = "plantuml-server"))]
 use crate::plantuml_server_backend::PlantUMLServer;
+#[cfg(not(feature = "exp-cmdline-pipe"))]
 use crate::plantuml_shell_backend::PlantUMLShell;
 use crate::plantumlconfig::PlantUMLConfig;
 use anyhow::{bail, Result};
@@ -29,7 +32,7 @@ fn create_backend(cmd: &str) -> Box<dyn PlantUMLBackend> {
     if let Ok(server_url) = Url::parse(cmd) {
         Box::new(PlantUMLServer::new(server_url))
     } else {
-        Box::new(PlantUMLShell::new(cmd.to_string()))
+        create_executable_backend(cmd)
     }
 }
 
@@ -38,15 +41,25 @@ fn create_backend(cmd: &str) -> Box<dyn PlantUMLBackend> {
     if cmd.starts_with("http://") || cmd.starts_with("https://") {
         Box::new(PlantUMLNoServerErrorBackend {})
     } else {
-        Box::new(PlantUMLShell::new(cmd.to_string()))
+        create_executable_backend(cmd)
     }
+}
+
+#[cfg(not(feature = "exp-cmdline-pipe"))]
+fn create_executable_backend(cmd: &str) -> Box<dyn PlantUMLBackend> {
+    Box::new(PlantUMLShell::new(cmd.to_string()))
+}
+
+#[cfg(feature = "exp-cmdline-pipe")]
+fn create_executable_backend(cmd: &str) -> Box<dyn PlantUMLBackend> {
+    Box::new(PlantUMLExecutableBackend::new(cmd.to_string(), None))
 }
 
 struct PlantUMLNoServerErrorBackend;
 impl PlantUMLBackend for PlantUMLNoServerErrorBackend {
     /// Display an error message when the user built the plugin without server
     /// support, but does configure a server in book.toml.
-    fn render_from_string(&self, _: &str, _: &str, _: &Path) -> Result<()> {
+    fn render_from_string(&self, _: &str, _: &str, _: &str, _: &Path) -> Result<()> {
         bail!(
             "A PlantUML server is configured, but the mdbook-plantuml plugin \
             is built without server support.\nPlease rebuild/reinstall the \

--- a/src/plantuml_cmdline_backend.rs
+++ b/src/plantuml_cmdline_backend.rs
@@ -1,0 +1,191 @@
+use crate::plantuml_backend::PlantUMLBackend;
+use anyhow::{bail, Result};
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// A trait class for wrapping the actual rendering command.
+///
+/// Only here to make unit testing the renderer possible, this is cheating a
+/// bit, but the other option is not testing it at all, or partially through
+/// integration tests.
+pub trait CommandExecutor {
+    fn execute(&self, dir: &str, args: Vec<String>, input: &[u8]) -> Result<Vec<u8>>;
+}
+
+pub struct RealCommandExecutor;
+
+impl CommandExecutor for RealCommandExecutor {
+    fn execute(&self, dir: &str, args: Vec<String>, input: &[u8]) -> Result<Vec<u8>> {
+        let mut command = Command::new(&args[0]);
+        command.args(&args[1..]).current_dir(dir);
+
+        log::debug!("Command: {:?}", &command);
+        log::debug!("Working dir {:?}", dir);
+
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let mut stdin = match child.stdin.take() {
+            Some(val) => val,
+            None => bail!("Cannot take stdin!"),
+        };
+        stdin.write_all(input)?;
+        log::debug!("{} bytes written", input.len());
+        drop(stdin); // IMPORTANT!!! If omitted plantuml will halt!
+
+        let output = child.wait_with_output()?;
+        if output.status.success() {
+            log::debug!("Command success {:?}", output.status);
+        } else {
+            log::error!(
+                "Command error {:?}: {:?}",
+                output.status,
+                String::from_utf8_lossy(output.stderr.as_slice())
+            );
+            bail!(
+                "Command error {:?}",
+                String::from_utf8_lossy(output.stderr.as_slice()),
+            );
+        }
+
+        Ok(output.stdout)
+    }
+}
+
+pub struct PlantUMLExecutableBackend {
+    args: Vec<String>,
+    executor: Box<dyn CommandExecutor>,
+}
+
+/// Invokes PlantUML as a shell/cmd program.
+impl PlantUMLExecutableBackend {
+    pub fn new(command: String, executor: Option<Box<dyn CommandExecutor>>) -> Self {
+        Self {
+            args: command.split_whitespace().map(|a| a.to_owned()).collect(),
+            executor: match executor {
+                Some(v) => v,
+                None => Box::new(RealCommandExecutor),
+            },
+        }
+    }
+}
+
+impl PlantUMLBackend for PlantUMLExecutableBackend {
+    /// Generate an image file from the given plantuml code.
+    fn render_from_string(
+        &self,
+        plantuml_code: &str,
+        chapter_path: &str,
+        image_format: &str,
+        output_file: &Path,
+    ) -> Result<()> {
+        let mut args: Vec<String> = self.args.clone();
+        args.push(format!("-t{}", image_format));
+        args.push(String::from("-nometadata"));
+        args.push(String::from("-pipe"));
+
+        let output = self
+            .executor
+            .execute(chapter_path, args, plantuml_code.as_bytes())?;
+        fs::write(output_file, &output)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::join_path;
+    use anyhow::bail;
+    use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
+
+    const THE_ERROR: &str = "The ERROR!";
+    const TEST_DIR: &str = "testdir";
+
+    struct FakeCommandExecutor {
+        expect_dir: String,
+        error: bool,
+        output: Box<Vec<u8>>,
+    }
+
+    impl CommandExecutor for FakeCommandExecutor {
+        fn execute(&self, dir: &str, _: Vec<String>, _: &[u8]) -> Result<Vec<u8>> {
+            assert_eq!(self.expect_dir.as_str(), dir);
+
+            if self.error {
+                bail!(THE_ERROR)
+            }
+
+            Ok(self.output.as_ref().clone())
+        }
+    }
+
+    fn run_render_from_string(
+        source: Option<&String>,
+        output: Option<&String>,
+        generate_error: bool,
+        read_result: bool,
+    ) -> Result<String> {
+        let output_dir = tempdir().unwrap();
+        let output_data: Vec<u8> = match output {
+            Some(data) => data.clone().into_bytes(),
+            None => Vec::default(),
+        };
+        let output_file = join_path(output_dir.path(), "foobar.svg");
+
+        let executor: Box<dyn CommandExecutor> = Box::new(FakeCommandExecutor {
+            expect_dir: String::from(TEST_DIR),
+            error: generate_error,
+            output: Box::new(output_data),
+        });
+        let backend: Box<dyn PlantUMLBackend> = Box::new(PlantUMLExecutableBackend {
+            args: vec![String::from("plantuml")],
+            executor,
+        });
+
+        backend.render_from_string(
+            source.map_or("@startuml\nA--|>B\n@enduml", AsRef::as_ref),
+            TEST_DIR,
+            "svg",
+            &output_file,
+        )?;
+
+        if read_result {
+            let raw_source = fs::read(&output_file)?;
+            return Ok(String::from_utf8_lossy(&raw_source).into_owned());
+        }
+
+        Ok(String::default())
+    }
+
+    #[test]
+    fn command_failure() {
+        match run_render_from_string(None, None, true, false) {
+            Ok(_file_data) => panic!("Expected the command to fail"),
+            Err(e) => assert_eq!(e.to_string(), THE_ERROR),
+        };
+    }
+
+    #[test]
+    fn returns_image_file_path_on_success() {
+        let expected_output = String::from("svg code here");
+        match run_render_from_string(
+            Some(&String::from("My plantuml code")),
+            Some(&expected_output),
+            false,
+            true,
+        ) {
+            Ok(file_data) => {
+                assert_eq!(expected_output, file_data);
+            }
+            Err(e) => panic!("{}", e),
+        };
+    }
+}

--- a/src/plantuml_renderer.rs
+++ b/src/plantuml_renderer.rs
@@ -58,7 +58,7 @@ impl PlantUMLRenderer {
         let renderer = Self {
             backend: plantuml_backend_factory::create(cfg),
             cleaner: RefCell::new(DirCleaner::new(img_root.as_path())),
-            img_root: img_root,
+            img_root,
             clickable_img: cfg.clickable_img,
             use_data_uris: cfg.use_data_uris,
         };

--- a/src/plantuml_server_backend.rs
+++ b/src/plantuml_server_backend.rs
@@ -96,6 +96,7 @@ impl PlantUMLBackend for PlantUMLServer {
     fn render_from_string(
         &self,
         plantuml_code: &str,
+        _chapter_path: &str,
         image_format: &str,
         output_file: &Path,
     ) -> Result<()> {

--- a/src/plantuml_shell_backend.rs
+++ b/src/plantuml_shell_backend.rs
@@ -166,6 +166,7 @@ impl PlantUMLBackend for PlantUMLShell {
     fn render_from_string(
         &self,
         plantuml_code: &str,
+        _chapter_path: &str,
         image_format: &str,
         output_file: &Path,
     ) -> Result<()> {

--- a/src/plantuml_shell_backend.rs
+++ b/src/plantuml_shell_backend.rs
@@ -44,7 +44,7 @@ impl CommandExecutor for RealCommandExecutor {
             // If not done this way sh -c will ignore all data after the first
             // argument (e.g. ```sh -c plantuml source.puml``` will become
             // ```sh -c plantuml```.
-            .arg(args.join(" "))
+            .args(args)
             .output()
             .expect("Failed to start PlantUML application");
 


### PR DESCRIPTION
Added the ability of generating diagram through `plantuml -pipe` command without using temporary diagram source files generation.

Which allow us to use such kind of plantuml code with relative imports paths.

```plantuml
@startuml
!include diagram.puml
@enduml
```

Due to lack of tests to cover the edge cases of added implementation I hid this functional under the feature flag called `exp-cmdline-pipe`.
Then enabled it's replaces the original shell  command implementation with the new one.

