### PR TITLE
allow dependabot to bump cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: monthly
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
allows dependabot to also manage cargo dependencies.

This has the potential to be a bit noisy, since this is a binary (as opposed to a library), which means any change to deps can result a new PR, not just major changes.
To mitigate this, i've clamped the frequency to monthly checks.